### PR TITLE
Fix missing tooltip module import for blog layout

### DIFF
--- a/src/app/blog/blog-layout.component.ts
+++ b/src/app/blog/blog-layout.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterOutlet } from '@angular/router';
 import { findMainContentContainer, scrollTo } from '../../utils';
 
@@ -23,7 +24,7 @@ import { findMainContentContainer, scrollTo } from '../../utils';
       </button>
     </div>
   `,
-  imports: [RouterOutlet, MatButtonModule, MatIconModule],
+  imports: [RouterOutlet, MatButtonModule, MatIconModule, MatTooltipModule],
 })
 export class BlogLayoutComponent {
   goTop(contentElement: HTMLElement) {


### PR DESCRIPTION
## Summary
- import `MatTooltipModule` in `BlogLayoutComponent` so its tooltip directive can compile

## Testing
- npm test
- npm run lint
- npm run build -- --configuration development --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68ccbaa41f0c8321ab727a53479a6ad9